### PR TITLE
Add `return` to prevent TypeError

### DIFF
--- a/src/Isolate.php
+++ b/src/Isolate.php
@@ -252,7 +252,7 @@ class Isolate extends Plugin
 
     public function getSettingsResponse()
     {
-        Craft::$app->controller->redirect(UrlHelper::cpUrl('isolate/settings'));
+        return Craft::$app->controller->redirect(UrlHelper::cpUrl('isolate/settings'));
     }
 
     // Protected Methods


### PR DESCRIPTION
Thanks for updating this to work with Craft 4! I found a little hiccup when opening the Plugin settings from the Settings page. 